### PR TITLE
Add exception traces to error report

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -53,7 +53,7 @@ def simple_download(url):
         return resp.read().decode('utf-8')
     except Exception as E:
         print(f"Could not hit {url}: {E}")
-    return None
+        raise E
 
 
 # for same-host redirects

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -251,7 +251,7 @@ def summarize_everything(good, bad, origin_request):
     if bad:
         final_report += "\nFailed Downloads:\n"
     for b in bad:
-        final_report += f"  - {b['url']} failed w/ {b['code']} waisting {b['overhead']:.01f}ms\n"
+        final_report += f"  - {b['url']} failed w/ {b['code']} (overhead: {b['overhead']:.01f}ms)\n"
         # If we have a redirect, add the traceback
         if len(b['tb']) > 1:
             final_report += format_tb(b['tb']) + "\n"


### PR DESCRIPTION
Sometimes the error report just contains the message of a TypeError due to exceptions being swallowed and replaced with a None return value. This PR adds the full exception trace to the error message and removes the exception swallowing so that the original error can bubble up all the way to the appropriate exception handler.

You can ignore the whitespace changes to fix linter errors in the review tab under the cog menu:
![image](https://user-images.githubusercontent.com/97191414/189411456-76dd90a2-c833-4d05-97e2-5764432376fb.png)
